### PR TITLE
Resolved Multiple Issues - Working Version :) 

### DIFF
--- a/infra.yaml
+++ b/infra.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Description: "VPC Infrastructure with IPv4/IPv6 Subnets, NAT Gateways, VPC Lattice, and EC2 Instances"
+Description: "VPC Infrastructure with IPv4/IPv6 Subnets, NAT-Gateways, VPC Lattice, and EC2 Instances"
 
 Parameters:
   LatestAmiId:

--- a/infra.yaml
+++ b/infra.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Description: "VPC Infrastructure with IPv4/IPv6 Subnets, NAT-Gateways, VPC Lattice, and EC2 Instances"
+Description: "VPC Infrastructure with IPv4/IPv6 Subnets, NAT Gateways, VPC Lattice, and EC2 Instances"
 
 Parameters:
   LatestAmiId:

--- a/infra.yaml
+++ b/infra.yaml
@@ -1,22 +1,25 @@
 AWSTemplateFormatVersion: "2010-09-09"
-
-Description: "EC2 instances and VPC Resources"
+Description: "VPC Infrastructure with IPv4/IPv6 Subnets, NAT Gateways, VPC Lattice, and EC2 Instances"
 
 Parameters:
   LatestAmiId:
     Type: "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>"
     Default: "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2"
-  SSHClientIP:
+    Description: "Latest Amazon Linux 2 AMI"
+
+  VPCLatticeIPv4PrefixList:
     Type: String
-    Default: "1.1.1.1/32"
-    Description: "Enter the IP address of SSH Client. You'll SSH into the IPv6 only instance from this SSH Client machine."
-  SSHClientIPv6:
+    Default: pl-07cbd8b5e26960eac
+    Description: VPC Lattice IPv4 Prefix List ID for us-east-1
+    
+  VPCLatticeIPv6PrefixList:
     Type: String
-    Default: "2001:db8::1:2:3/128"
-    Description: "Enter the IPv6 address of SSH Client. You'll SSH into the IPv6 only instance from this SSH Client machine."
+    Default: pl-073555187c4e6ccf2
+    Description: VPC Lattice IPv6 Prefix List ID for us-east-1
+  
 
 Resources:
-# ---------- VPC, Endpoints, Internet Gateways, and SUBNETS ----------
+  # ---------- VPCs and IPv6 CIDRs ----------
   VPC1:
     Type: AWS::EC2::VPC
     Properties:
@@ -25,89 +28,15 @@ Resources:
       EnableDnsHostnames: true
       InstanceTenancy: default
       Tags: 
-        - 
-          Key: Name
-          Value: vpc-1
-  
+        - Key: Name
+          Value: VPC-1
+
   VPC1IPv6CIDR:
     Type: AWS::EC2::VPCCidrBlock
     Properties:
       AmazonProvidedIpv6CidrBlock: true
       VpcId: !Ref VPC1
 
-  VPC1IPv4Subnet:
-    Type: AWS::EC2::Subnet
-    Properties:
-      VpcId: !Ref VPC1
-      AvailabilityZone: !Sub ${AWS::Region}a
-      CidrBlock: 10.1.1.0/24
-      Tags:
-        -
-          Key: Name
-          Value: vpc-1-ipv4-subnet
-
-  VPC1IPv6Subnet:
-    DependsOn:
-      - VPC1IPv6CIDR
-    Type: AWS::EC2::Subnet
-    Properties:
-      VpcId: !Ref VPC1
-      AvailabilityZone: !Sub ${AWS::Region}b
-      Ipv6Native: true
-      Ipv6CidrBlock:
-        Fn::Sub:
-          - "${VpcPart}${SubnetPart}"
-          - SubnetPart: '02::/64'
-            VpcPart: !Select [ 0, !Split [ '00::/56', !Select [ 0, !GetAtt VPC1.Ipv6CidrBlocks ]]]
-      Tags:
-        -
-          Key: Name
-          Value: vpc-1-ipv6-subnet
-
-  VPC1EndpointsSubnet1:
-    DependsOn:
-      - VPC1IPv6CIDR
-    Type: AWS::EC2::Subnet
-    Properties:
-      VpcId: !Ref VPC1
-      AvailabilityZone: !Sub ${AWS::Region}a
-      CidrBlock: 10.1.3.0/24
-      Ipv6CidrBlock:
-        Fn::Sub:
-          - "${VpcPart}${SubnetPart}"
-          - SubnetPart: '03::/64'
-            VpcPart: !Select [ 0, !Split [ '00::/56', !Select [ 0, !GetAtt VPC1.Ipv6CidrBlocks ]]]
-      Tags:
-        -
-          Key: Name
-          Value: vpc-1-endpoints-subnet-1
-
-  VPC1EndpointsSubnet2:
-    DependsOn:
-      - VPC1IPv6CIDR
-    Type: AWS::EC2::Subnet
-    Properties:
-      VpcId: !Ref VPC1
-      AvailabilityZone: !Sub ${AWS::Region}b
-      CidrBlock: 10.1.4.0/24
-      Ipv6CidrBlock:
-        Fn::Sub:
-          - "${VpcPart}${SubnetPart}"
-          - SubnetPart: '04::/64'
-            VpcPart: !Select [ 0, !Split [ '00::/56', !Select [ 0, !GetAtt VPC1.Ipv6CidrBlocks ]]]
-      Tags:
-        -
-          Key: Name
-          Value: vpc-1-endpoints-subnet-2
-    
-  VPC1IGW:
-    Type: AWS::EC2::InternetGateway
-    Properties:
-      Tags:
-      - Key: stack
-        Value: production
-
-# VPC 2 Resources
   VPC2:
     Type: AWS::EC2::VPC
     Properties:
@@ -116,44 +45,496 @@ Resources:
       EnableDnsHostnames: true
       InstanceTenancy: default
       Tags: 
-        - 
-          Key: Name
-          Value: vpc-2
-  
+        - Key: Name
+          Value: VPC-2
+
   VPC2IPv6CIDR:
     Type: AWS::EC2::VPCCidrBlock
     Properties:
       AmazonProvidedIpv6CidrBlock: true
       VpcId: !Ref VPC2
 
-  VPC2IPv4Subnet:
+  # ---------- Internet Gateways and Attachments ----------
+  VPC1IGW:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: VPC1-IGW
+
+  VPC2IGW:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: VPC2-IGW
+
+  VPC1IGWAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref VPC1
+      InternetGatewayId: !Ref VPC1IGW
+
+  VPC2IGWAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref VPC2
+      InternetGatewayId: !Ref VPC2IGW
+
+  # ---------- Egress-Only Internet Gateways ----------
+  VPC1EIGW:
+    Type: AWS::EC2::EgressOnlyInternetGateway
+    Properties:
+      VpcId: !Ref VPC1
+
+  VPC2EIGW:
+    Type: AWS::EC2::EgressOnlyInternetGateway
+    Properties:
+      VpcId: !Ref VPC2
+
+  # ---------- Security Groups ----------
+  VPC1InstanceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupName: vpc-1-instance-sg
+      GroupDescription: Instance Security Group for VPC1
+      VpcId: !Ref VPC1
+      SecurityGroupIngress:
+        - Description: Allow HTTP from VPC Lattice IPv4
+          IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          SourcePrefixListId: !Ref VPCLatticeIPv4PrefixList
+        - Description: Allow HTTP from VPC Lattice IPv6
+          IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          SourcePrefixListId: !Ref VPCLatticeIPv6PrefixList
+      SecurityGroupEgress:
+        - IpProtocol: "-1"
+          FromPort: -1
+          ToPort: -1
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: "-1"
+          FromPort: -1
+          ToPort: -1
+          CidrIpv6: ::/0
+      Tags:
+        - Key: Name
+          Value: VPC1-Instance-SG
+
+  VPC1EndpointsSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupName: vpc-1-endpoints-sg
+      GroupDescription: Endpoints Security Group for VPC1
+      VpcId: !Ref VPC1
+      SecurityGroupIngress:
+        - Description: Allow HTTPS from instances
+          IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          SourceSecurityGroupId: !Ref VPC1InstanceSecurityGroup
+        - Description: Allow HTTPS from VPC1NATGW1 Subnet CIDR
+          IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 10.1.10.0/24
+        - Description: Allow HTTPS from VPC1NATGW2 Subnet CIDR
+          IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 10.1.11.0/24
+      SecurityGroupEgress:
+        - IpProtocol: "-1"
+          FromPort: -1
+          ToPort: -1
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: "-1"
+          FromPort: -1
+          ToPort: -1
+          CidrIpv6: ::/0
+      Tags:
+        - Key: Name
+          Value: VPC1-Endpoints-SG
+
+  VPC1LatticeSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupName: vpc-1-lattice-sg
+      GroupDescription: VPC Lattice Security Group for VPC1
+      VpcId: !Ref VPC1
+      SecurityGroupIngress:
+        - Description: Allow HTTP from instances
+          IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          SourceSecurityGroupId: !Ref VPC1InstanceSecurityGroup
+        - Description: Allow HTTPS from instances
+          IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          SourceSecurityGroupId: !Ref VPC1InstanceSecurityGroup
+      SecurityGroupEgress:
+        - IpProtocol: "-1"
+          FromPort: -1
+          ToPort: -1
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: "-1"
+          FromPort: -1
+          ToPort: -1
+          CidrIpv6: ::/0
+      Tags:
+        - Key: Name
+          Value: VPC1-Lattice-SG
+
+  VPC2InstanceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupName: vpc-2-instance-sg
+      GroupDescription: Instance Security Group for VPC2
+      VpcId: !Ref VPC2
+      SecurityGroupIngress:
+        - Description: Allow HTTP from VPC Lattice IPv4
+          IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          SourcePrefixListId: !Ref VPCLatticeIPv4PrefixList
+        - Description: Allow HTTP from VPC Lattice IPv6
+          IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          SourcePrefixListId: !Ref VPCLatticeIPv6PrefixList
+      SecurityGroupEgress:
+        - IpProtocol: "-1"
+          FromPort: -1
+          ToPort: -1
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: "-1"
+          FromPort: -1
+          ToPort: -1
+          CidrIpv6: ::/0
+      Tags:
+        - Key: Name
+          Value: VPC2-Instance-SG
+
+  VPC2EndpointsSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupName: vpc-2-endpoints-sg
+      GroupDescription: Endpoints Security Group for VPC2
+      VpcId: !Ref VPC2
+      SecurityGroupIngress:
+        - Description: Allow HTTPS from instances
+          IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          SourceSecurityGroupId: !Ref VPC2InstanceSecurityGroup
+        - Description: Allow HTTPS from VPC2NATGW1 Subnet CIDR
+          IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 10.2.1.0/24
+        - Description: Allow HTTPS from VPC2NATGW2 Subnet CIDR
+          IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 10.2.11.0/24
+      SecurityGroupEgress:
+        - IpProtocol: "-1"
+          FromPort: -1
+          ToPort: -1
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: "-1"
+          FromPort: -1
+          ToPort: -1
+          CidrIpv6: ::/0
+      Tags:
+        - Key: Name
+          Value: VPC2-Endpoints-SG
+
+  VPC2LatticeSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupName: vpc-2-lattice-sg
+      GroupDescription: VPC Lattice Security Group for VPC2
+      VpcId: !Ref VPC2
+      SecurityGroupIngress:
+        - Description: Allow HTTP from instances
+          IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          SourceSecurityGroupId: !Ref VPC2InstanceSecurityGroup
+        - Description: Allow HTTPS from instances
+          IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          SourceSecurityGroupId: !Ref VPC2InstanceSecurityGroup
+      SecurityGroupEgress:
+        - IpProtocol: "-1"
+          FromPort: -1
+          ToPort: -1
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: "-1"
+          FromPort: -1
+          ToPort: -1
+          CidrIpv6: ::/0
+      Tags:
+        - Key: Name
+          Value: VPC2-Lattice-SG
+
+  # ---------- Route Tables ----------
+  VPC1PublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC1
+      Tags:
+        - Key: Name
+          Value: VPC1-Public-RT
+
+  VPC1IPv4OnlySubnetRouteTable1:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC1
+      Tags:
+        - Key: Name
+          Value: VPC1-IPV4-RT-AZ1
+
+  VPC1IPv6OnlySubnetRouteTable2:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC1
+      Tags:
+        - Key: Name
+          Value: VPC1-IPV6-RT-AZ2
+
+  VPC2PublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC2
+      Tags:
+        - Key: Name
+          Value: VPC2-Public-RT
+
+  VPC2IPv4OnlySubnetRouteTable1:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC2
+      Tags:
+        - Key: Name
+          Value: VPC2-IPV4-RT-AZ1
+
+  VPC2DualStackSubnetRouteTable2:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC2
+      Tags:
+        - Key: Name
+          Value: VPC2-DualStack-RT-AZ2
+
+  # ---------- Elastic IPs for NAT Gateways ----------
+  VPC1EIP1:
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: vpc
+      Tags:
+        - Key: Name
+          Value: VPC1-NAT-EIP1
+
+  VPC1EIP2:
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: vpc
+      Tags:
+        - Key: Name
+          Value: VPC1-NAT-EIP2
+
+  VPC2EIP1:
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: vpc
+      Tags:
+        - Key: Name
+          Value: VPC2-NAT-EIP1
+
+  VPC2EIP2:
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: vpc
+      Tags:
+        - Key: Name
+          Value: VPC2-NAT-EIP2
+
+  # ---------- Subnets ----------
+  # VPC1 Public Subnets
+  VPC1PublicSubnet1:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC1
+      AvailabilityZone: !Select [0, !GetAZs ""]
+      CidrBlock: 10.1.10.0/24
+      Ipv6CidrBlock:
+        Fn::Select: 
+          - 2
+          - Fn::Cidr: 
+            - !Select [0, !GetAtt VPC1.Ipv6CidrBlocks]
+            - 6
+            - 64
+      Tags:
+        - Key: Name
+          Value: VPC1-Public-Subnet-1
+
+  VPC1PublicSubnet2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC1
+      AvailabilityZone: !Select [1, !GetAZs ""]
+      CidrBlock: 10.1.11.0/24
+      Ipv6CidrBlock:
+        Fn::Select: 
+          - 5
+          - Fn::Cidr: 
+            - !Select [0, !GetAtt VPC1.Ipv6CidrBlocks]
+            - 6
+            - 64
+      Tags:
+        - Key: Name
+          Value: VPC1-Public-Subnet-2      
+
+  # VPC1 Private Subnets
+  VPC1IPv4OnlySubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC1
+      AvailabilityZone: !Select [0, !GetAZs ""]
+      CidrBlock: 10.1.0.0/24
+      Tags:
+        - Key: Name
+          Value: VPC1-IPv4-Only-Subnet
+
+  VPC1IPv6OnlySubnet:
+    Type: AWS::EC2::Subnet
+    DependsOn: VPC1IPv6CIDR
+    Properties:
+      VpcId: !Ref VPC1
+      AvailabilityZone: !Select [1, !GetAZs ""]
+      Ipv6Native: true
+      EnableDns64: true
+      Ipv6CidrBlock:
+        Fn::Select: 
+          - 0
+          - Fn::Cidr: 
+            - !Select [0, !GetAtt VPC1.Ipv6CidrBlocks]
+            - 6
+            - 64
+      AssignIpv6AddressOnCreation: true
+      Tags:
+        - Key: Name
+          Value: VPC1-IPv6-Only-Subnet
+
+  VPC1EndpointsSubnet1:
+    DependsOn: VPC1IPv6CIDR
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC1
+      AvailabilityZone: !Select [0, !GetAZs ""]
+      CidrBlock: 10.1.3.0/24
+      Ipv6CidrBlock:
+        Fn::Select: 
+          - 3
+          - Fn::Cidr: 
+            - !Select [0, !GetAtt VPC1.Ipv6CidrBlocks]
+            - 6
+            - 64
+      AssignIpv6AddressOnCreation: true
+      Tags:
+        - Key: Name
+          Value: VPC1-Endpoints-Subnet-1
+
+  VPC1EndpointsSubnet2:
+    DependsOn: VPC1IPv6CIDR
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC1
+      AvailabilityZone: !Select [1, !GetAZs ""]
+      CidrBlock: 10.1.4.0/24
+      Ipv6CidrBlock:
+        Fn::Select: 
+          - 4
+          - Fn::Cidr: 
+            - !Select [0, !GetAtt VPC1.Ipv6CidrBlocks]
+            - 6
+            - 64
+      AssignIpv6AddressOnCreation: true
+      Tags:
+        - Key: Name
+          Value: VPC1-Endpoints-Subnet-2
+
+  # VPC2 Public Subnets
+  VPC2PublicSubnet1:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC2
-      AvailabilityZone: !Sub ${AWS::Region}a
+      AvailabilityZone: !Select [0, !GetAZs ""]
       CidrBlock: 10.2.1.0/24
+      Ipv6CidrBlock: 
+        Fn::Select: 
+          - 2
+          - Fn::Cidr: 
+            - !Select [0, !GetAtt VPC2.Ipv6CidrBlocks]
+            - 6
+            - 64
       Tags:
-        -
-          Key: Name
-          Value: vpc-2-ipv4-subnet
+        - Key: Name
+          Value: VPC2-Public-Subnet-1
+
+  VPC2PublicSubnet2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC2
+      AvailabilityZone: !Select [1, !GetAZs ""]
+      CidrBlock: 10.2.11.0/24
+      Ipv6CidrBlock: 
+        Fn::Select: 
+          - 5
+          - Fn::Cidr: 
+            - !Select [0, !GetAtt VPC2.Ipv6CidrBlocks]
+            - 6
+            - 64
+      Tags:
+        - Key: Name
+          Value: VPC2-Public-Subnet-2
+
+  # VPC2 Private Subnets
+  VPC2IPv4OnlySubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC2
+      AvailabilityZone: !Select [0, !GetAZs ""]
+      CidrBlock: 10.2.20.0/24
+      Tags:
+        - Key: Name
+          Value: VPC2-IPv4-Only-Subnet
 
   VPC2DualStackSubnet:
-    DependsOn:
-      - VPC2IPv6CIDR
     Type: AWS::EC2::Subnet
+    DependsOn: VPC2IPv6CIDR
     Properties:
       VpcId: !Ref VPC2
-      CidrBlock: 10.2.2.0/24
-      AvailabilityZone: !Sub ${AWS::Region}b
-      Ipv6CidrBlock:
-        Fn::Sub:
-          - "${VpcPart}${SubnetPart}"
-          - SubnetPart: '02::/64'
-            VpcPart: !Select [ 0, !Split [ '00::/56', !Select [ 0, !GetAtt VPC2.Ipv6CidrBlocks ]]]
+      AvailabilityZone: !Select [1, !GetAZs ""]
+      CidrBlock: 10.2.10.0/24
+      EnableDns64: true
+      Ipv6CidrBlock: 
+        Fn::Select: 
+          - 0
+          - Fn::Cidr: 
+            - !Select [0, !GetAtt VPC2.Ipv6CidrBlocks]
+            - 6
+            - 64
+      AssignIpv6AddressOnCreation: true
       Tags:
-        -
-          Key: Name
-          Value: vpc-2-dual-stack-subnet
+        - Key: Name
+          Value: VPC2DualStackSubnet-2
 
   VPC2EndpointsSubnet1:
     DependsOn:
@@ -161,17 +542,19 @@ Resources:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC2
-      AvailabilityZone: !Sub ${AWS::Region}a
+      AvailabilityZone: !Select [0, !GetAZs ""]
       CidrBlock: 10.2.3.0/24
-      Ipv6CidrBlock:
-        Fn::Sub:
-          - "${VpcPart}${SubnetPart}"
-          - SubnetPart: '03::/64'
-            VpcPart: !Select [ 0, !Split [ '00::/56', !Select [ 0, !GetAtt VPC2.Ipv6CidrBlocks ]]]
+      Ipv6CidrBlock: 
+        Fn::Select: 
+          - 3
+          - Fn::Cidr: 
+            - !Select [0, !GetAtt VPC2.Ipv6CidrBlocks]
+            - 6
+            - 64
+      AssignIpv6AddressOnCreation: true
       Tags:
-        -
-          Key: Name
-          Value: vpc-2-endpoints-subnet-1
+        - Key: Name
+          Value: VPC2-Endpoints-Subnet-1
 
   VPC2EndpointsSubnet2:
     DependsOn:
@@ -179,323 +562,331 @@ Resources:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC2
-      AvailabilityZone: !Sub ${AWS::Region}b
+      AvailabilityZone: !Select [1, !GetAZs ""]
       CidrBlock: 10.2.4.0/24
-      Ipv6CidrBlock:
-        Fn::Sub:
-          - "${VpcPart}${SubnetPart}"
-          - SubnetPart: '04::/64'
-            VpcPart: !Select [ 0, !Split [ '00::/56', !Select [ 0, !GetAtt VPC2.Ipv6CidrBlocks ]]]
-      Tags:
-        -
-          Key: Name
-          Value: vpc-2-endpoints-subnet-2
-
-# ---------- LATTICE VPC ASSOCIATION ----------
-  LatticeVPC1Association:
-    Type: AWS::VpcLattice::ServiceNetworkVpcAssociation
-    Properties:
-      SecurityGroupIds:
-        - !Ref VPC1LatticeSecurityGroup
-      ServiceNetworkIdentifier: !Ref ServiceNetwork
-      VpcIdentifier: !Ref VPC1
-
-  LatticeVPC2Association:
-    Type: AWS::VpcLattice::ServiceNetworkVpcAssociation
-    Properties:
-      SecurityGroupIds:
-        - !Ref VPC2LatticeSecurityGroup
-      ServiceNetworkIdentifier: !Ref ServiceNetwork
-      VpcIdentifier: !Ref VPC2
-    
-# ---------- SECURITY GROUPS ----------
-  VPC1InstanceSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupName: vpc-1-instance-sg
-      GroupDescription: Instance Security Group
-      VpcId: !Ref VPC1
-      SecurityGroupIngress:
-        - Description: Allowing TCP port 80 traffic
-          IpProtocol: tcp
-          FromPort: 80
-          ToPort: 80
-          CidrIp: 169.254.171.0/24
-        - Description: Allowing SSH from SSH Client
-          IpProtocol: tcp
-          FromPort: 22
-          ToPort: 22
-          CidrIp: !Ref SSHClientIP
-        - Description: Allowing SSH from IPv6 Client
-          IpProtocol: tcp
-          FromPort: 22
-          ToPort: 22
-          CidrIpv6: !Ref SSHClientIPv6
-      SecurityGroupEgress:
-        - IpProtocol: "-1"
-          CidrIp: "0.0.0.0/0"
-        - IpProtocol: "-1"
-          CidrIpv6: "::/0"
-             
-  VPC1EndpointsSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupName: vpc-1-endpoints-sg
-      GroupDescription: Endpoints Security Group
-      VpcId: !Ref VPC1
-      SecurityGroupIngress:
-        - Description: Allowing HTTPS
-          IpProtocol: tcp
-          FromPort: 443
-          ToPort: 443
-          SourceSecurityGroupId: !Ref VPC1InstanceSecurityGroup
-      SecurityGroupEgress:
-        - IpProtocol: "-1"
-          CidrIp: "0.0.0.0/0"
-        - IpProtocol: "-1"
-          CidrIpv6: "::/0"
-  
-  VPC1LatticeSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupName: vpc-1-lattice-sg
-      GroupDescription: VPC Lattice Security Group
-      VpcId: !Ref VPC1
-      SecurityGroupIngress:
-        - Description: Allowing HTTP
-          IpProtocol: tcp
-          FromPort: 80
-          ToPort: 80
-          SourceSecurityGroupId: !Ref VPC1InstanceSecurityGroup
-        - Description: Allowing HTTPS
-          IpProtocol: tcp
-          FromPort: 443
-          ToPort: 443
-          SourceSecurityGroupId: !Ref VPC1InstanceSecurityGroup
-      SecurityGroupEgress:
-        - IpProtocol: "-1"
-          CidrIp: "0.0.0.0/0"
-        - IpProtocol: "-1"
-          CidrIpv6: "::/0"
-      
-
-  VPC2InstanceSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupName: vpc-2-instance-sg
-      GroupDescription: Instance Security Group
-      VpcId: !Ref VPC2
-      SecurityGroupIngress:
-        - Description: Allowing TCP port 80 traffic
-          IpProtocol: tcp
-          FromPort: 80
-          ToPort: 80
-          CidrIp: 169.254.171.0/24
-        - Description: Allowing SSH from SSH Client
-          IpProtocol: tcp
-          FromPort: 22
-          ToPort: 22
-          CidrIp: !Ref SSHClientIP
-        - Description: Allowing SSH from IPv6 Client
-          IpProtocol: tcp
-          FromPort: 22
-          ToPort: 22
-          CidrIpv6: !Ref SSHClientIPv6
-      SecurityGroupEgress:
-        - IpProtocol: "-1"
-          CidrIp: "0.0.0.0/0"
-        - IpProtocol: "-1"
-          CidrIpv6: "::/0"
-  
-  VPC2EndpointsSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupName: vpc-2-endpoints-sg
-      GroupDescription: Endpoints Security Group
-      VpcId: !Ref VPC2
-      SecurityGroupIngress:
-        - Description: Allowing HTTPS
-          IpProtocol: tcp
-          FromPort: 443
-          ToPort: 443
-          SourceSecurityGroupId: !Ref VPC2InstanceSecurityGroup
-      SecurityGroupEgress:
-        - IpProtocol: "-1"
-          CidrIp: "0.0.0.0/0"
-        - IpProtocol: "-1"
-          CidrIpv6: "::/0"
-  
-  VPC2LatticeSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupName: vpc-2-lattice-sg
-      GroupDescription: VPC Lattice Security Group
-      VpcId: !Ref VPC2
-      SecurityGroupIngress:
-        - Description: Allowing HTTP
-          IpProtocol: tcp
-          FromPort: 80
-          ToPort: 80
-          SourceSecurityGroupId: !Ref VPC2InstanceSecurityGroup
-        - Description: Allowing HTTPS
-          IpProtocol: tcp
-          FromPort: 443
-          ToPort: 443
-          SourceSecurityGroupId: !Ref VPC2InstanceSecurityGroup
-      SecurityGroupEgress:
-        - IpProtocol: "-1"
-          CidrIp: "0.0.0.0/0"
-        - IpProtocol: "-1"
-          CidrIpv6: "::/0"
-
-# ---------- SSM ENDPOINTS ----------
-  VPC1SSMProdVPCEndpoint:
-    Type: AWS::EC2::VPCEndpoint
-    Properties:
-      ServiceName: !Sub com.amazonaws.${AWS::Region}.ssm
-      VpcId: !Ref VPC1
-      SubnetIds:
-        - !Ref VPC1EndpointsSubnet1
-        - !Ref VPC1EndpointsSubnet2
-      SecurityGroupIds:
-        - !Ref VPC1EndpointsSecurityGroup
-      VpcEndpointType: Interface
-      PrivateDnsEnabled: True
-
-  VPC1SSMMessagesProdVPCEndpoint:
-    Type: AWS::EC2::VPCEndpoint
-    Properties:
-      ServiceName: !Sub com.amazonaws.${AWS::Region}.ssmmessages
-      VpcId: !Ref VPC1
-      SubnetIds:
-        - !Ref VPC1EndpointsSubnet1
-        - !Ref VPC1EndpointsSubnet2
-      SecurityGroupIds:
-        - !Ref VPC1EndpointsSecurityGroup
-      VpcEndpointType: Interface
-      PrivateDnsEnabled: True
-
-  VPC1EC2MessagesProdVPCEndpoint:
-    Type: AWS::EC2::VPCEndpoint
-    Properties:
-      ServiceName: !Sub com.amazonaws.${AWS::Region}.ec2messages
-      VpcId: !Ref VPC1
-      SubnetIds:
-        - !Ref VPC1EndpointsSubnet1
-        - !Ref VPC1EndpointsSubnet2
-      SecurityGroupIds:
-        - !Ref VPC1EndpointsSecurityGroup
-      VpcEndpointType: Interface
-      PrivateDnsEnabled: True
-
-  VPC2SSMProdVPCEndpoint:
-    Type: AWS::EC2::VPCEndpoint
-    Properties:
-      ServiceName: !Sub com.amazonaws.${AWS::Region}.ssm
-      VpcId: !Ref VPC2
-      SubnetIds:
-        - !Ref VPC2EndpointsSubnet1
-        - !Ref VPC2EndpointsSubnet2
-      SecurityGroupIds:
-        - !Ref VPC2EndpointsSecurityGroup
-      VpcEndpointType: Interface
-      PrivateDnsEnabled: True
-
-  VPC2SSMMessagesProdVPCEndpoint:
-    Type: AWS::EC2::VPCEndpoint
-    Properties:
-      ServiceName: !Sub com.amazonaws.${AWS::Region}.ssmmessages
-      VpcId: !Ref VPC2
-      SubnetIds:
-        - !Ref VPC2EndpointsSubnet1
-        - !Ref VPC2EndpointsSubnet2
-      SecurityGroupIds:
-        - !Ref VPC2EndpointsSecurityGroup
-      VpcEndpointType: Interface
-      PrivateDnsEnabled: True
-
-  VPC2EC2MessagesProdVPCEndpoint:
-    Type: AWS::EC2::VPCEndpoint
-    Properties:
-      ServiceName: !Sub com.amazonaws.${AWS::Region}.ec2messages
-      VpcId: !Ref VPC2
-      SubnetIds:
-        - !Ref VPC2EndpointsSubnet1
-        - !Ref VPC2EndpointsSubnet2
-      SecurityGroupIds:
-        - !Ref VPC2EndpointsSecurityGroup
-      VpcEndpointType: Interface
-      PrivateDnsEnabled: True
-
-# Instances
-  VPC1IPv4Instance:
-    Type: AWS::EC2::Instance
-    Properties:
-      InstanceType: t3.micro
-      IamInstanceProfile: !Ref EC2SSMInstanceProfileWorkloads
-      ImageId: !Ref LatestAmiId
-      SecurityGroupIds:
-        - !Ref VPC1InstanceSecurityGroup
-      SubnetId: !Ref VPC1IPv4Subnet
+      Ipv6CidrBlock: 
+        Fn::Select: 
+          - 4
+          - Fn::Cidr: 
+            - !Select [0, !GetAtt VPC2.Ipv6CidrBlocks]
+            - 6
+            - 64
+      AssignIpv6AddressOnCreation: true
       Tags:
         - Key: Name
-          Value: VPC-1-IPv4-Instance
+          Value: VPC2-Endpoints-Subnet-2
 
-  VPC1IPv6Instance:
-    Type: AWS::EC2::Instance
+  # ---------- NAT Gateways ----------
+  VPC1NATGW1:
+    Type: AWS::EC2::NatGateway
+    DependsOn: VPC1IGWAttachment
     Properties:
-      InstanceType: t3.micro
-      IamInstanceProfile: !Ref EC2SSMInstanceProfileWorkloads
-      ImageId: !Ref LatestAmiId
-      SecurityGroupIds:
-        - !Ref VPC1InstanceSecurityGroup
-      SubnetId: !Ref VPC1IPv6Subnet
+      AllocationId: !GetAtt VPC1EIP1.AllocationId
+      SubnetId: !Ref VPC1PublicSubnet1
       Tags:
         - Key: Name
-          Value: VPC-1-IPv6-Instance
+          Value: VPC1-NATGW-AZ1
 
-  VPC2IPv4Instance:
-    Type: AWS::EC2::Instance
+  VPC1NATGW2:
+    Type: AWS::EC2::NatGateway
+    DependsOn: VPC1IGWAttachment
     Properties:
-      InstanceType: t3.micro
-      IamInstanceProfile: !Ref EC2SSMInstanceProfileWorkloads
-      ImageId: !Ref LatestAmiId
-      SecurityGroupIds:
-        - !Ref VPC2InstanceSecurityGroup
-      SubnetId: !Ref VPC2IPv4Subnet
+      AllocationId: !GetAtt VPC1EIP2.AllocationId
+      SubnetId: !Ref VPC1PublicSubnet2
       Tags:
         - Key: Name
-          Value: VPC-2-IPv4-Instance
+          Value: VPC1-NATGW-AZ2
 
-  VPC2DualStackInstance:
-    Type: AWS::EC2::Instance
+  VPC2NATGW1:
+    Type: AWS::EC2::NatGateway
+    DependsOn: VPC2IGWAttachment
     Properties:
-      InstanceType: t3.micro
-      IamInstanceProfile: !Ref EC2SSMInstanceProfileWorkloads
-      ImageId: !Ref LatestAmiId
-      SecurityGroupIds:
-        - !Ref VPC2InstanceSecurityGroup
+      AllocationId: !GetAtt VPC2EIP1.AllocationId
+      SubnetId: !Ref VPC2PublicSubnet1
+      Tags:
+        - Key: Name
+          Value: VPC2-NATGW-AZ1
+
+  VPC2NATGW2:
+    Type: AWS::EC2::NatGateway
+    DependsOn: VPC2IGWAttachment
+    Properties:
+      AllocationId: !GetAtt VPC2EIP2.AllocationId
+      SubnetId: !Ref VPC2PublicSubnet2
+      Tags:
+        - Key: Name
+          Value: VPC2-NATGW-AZ2
+
+  # ---------- Route Table Associations ----------
+  VPC1PublicSubnet1RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref VPC1PublicSubnet1
+      RouteTableId: !Ref VPC1PublicRouteTable
+
+  VPC1PublicSubnet2RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref VPC1PublicSubnet2
+      RouteTableId: !Ref VPC1PublicRouteTable
+
+  VPC1IPv4OnlySubnetRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref VPC1IPv4OnlySubnet
+      RouteTableId: !Ref VPC1IPv4OnlySubnetRouteTable1
+
+  VPC1IPv6OnlySubnetRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref VPC1IPv6OnlySubnet
+      RouteTableId: !Ref VPC1IPv6OnlySubnetRouteTable2
+
+  VPC2PublicSubnet1RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref VPC2PublicSubnet1
+      RouteTableId: !Ref VPC2PublicRouteTable
+
+  VPC2PublicSubnet2RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref VPC2PublicSubnet2
+      RouteTableId: !Ref VPC2PublicRouteTable
+
+  VPC2IPv4OnlySubnetRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref VPC2IPv4OnlySubnet
+      RouteTableId: !Ref VPC2IPv4OnlySubnetRouteTable1
+
+  VPC2DualStackSubnetRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
       SubnetId: !Ref VPC2DualStackSubnet
+      RouteTableId: !Ref VPC2DualStackSubnetRouteTable2
+
+  # ---------- Routes ----------
+  # VPC1 Public Routes
+  VPC1PublicDefaultRoute:
+    Type: AWS::EC2::Route
+    DependsOn: VPC1IGWAttachment
+    Properties:
+      RouteTableId: !Ref VPC1PublicRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref VPC1IGW
+
+  VPC1PublicDefaultIPv6Route:
+    Type: AWS::EC2::Route
+    DependsOn: VPC1IGWAttachment
+    Properties:
+      RouteTableId: !Ref VPC1PublicRouteTable
+      DestinationIpv6CidrBlock: ::/0
+      GatewayId: !Ref VPC1IGW
+
+  # VPC1 Private Routes
+  VPC1PrivateDefaultRoute1:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref VPC1IPv4OnlySubnetRouteTable1
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId: !Ref VPC1NATGW1
+
+  VPC1PrivateDefaultRoute2:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref VPC1IPv6OnlySubnetRouteTable2
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId: !Ref VPC1NATGW2
+
+  VPC1PrivateDefaultRoute3:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref VPC1IPv6OnlySubnetRouteTable2
+      DestinationIpv6CidrBlock: 64:ff9b::/96
+      NatGatewayId: !Ref VPC1NATGW2
+
+  VPC1PrivateDefaultIPv6Route1:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref VPC1IPv4OnlySubnetRouteTable1
+      DestinationIpv6CidrBlock: ::/0
+      EgressOnlyInternetGatewayId: !Ref VPC1EIGW
+
+  VPC1PrivateDefaultIPv6Route2:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref VPC1IPv6OnlySubnetRouteTable2
+      DestinationIpv6CidrBlock: ::/0
+      EgressOnlyInternetGatewayId: !Ref VPC1EIGW
+
+  # VPC2 Public Routes
+  VPC2PublicDefaultRoute:
+    Type: AWS::EC2::Route
+    DependsOn: VPC2IGWAttachment
+    Properties:
+      RouteTableId: !Ref VPC2PublicRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref VPC2IGW
+
+  VPC2PublicDefaultIPv6Route:
+    Type: AWS::EC2::Route
+    DependsOn: VPC2IGWAttachment
+    Properties:
+      RouteTableId: !Ref VPC2PublicRouteTable
+      DestinationIpv6CidrBlock: ::/0
+      GatewayId: !Ref VPC2IGW
+
+  # VPC2 Private Routes
+  VPC2PrivateDefaultRoute1:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref VPC2IPv4OnlySubnetRouteTable1
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId: !Ref VPC2NATGW1
+
+  VPC2PrivateDefaultRoute2:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref VPC2DualStackSubnetRouteTable2
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId: !Ref VPC2NATGW2
+
+  VPC2PrivateDefaultRoute3:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref VPC2DualStackSubnetRouteTable2
+      DestinationIpv6CidrBlock: 64:ff9b::/96
+      NatGatewayId: !Ref VPC2NATGW2
+
+  VPC2PrivateDefaultIPv6Route1:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref VPC2IPv4OnlySubnetRouteTable1
+      DestinationIpv6CidrBlock: ::/0
+      EgressOnlyInternetGatewayId: !Ref VPC2EIGW
+
+  VPC2PrivateDefaultIPv6Route2:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref VPC2DualStackSubnetRouteTable2
+      DestinationIpv6CidrBlock: ::/0
+      EgressOnlyInternetGatewayId: !Ref VPC2EIGW
+
+  # ---------- VPC Endpoints ----------
+  VPC1SSMEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      ServiceName: !Sub com.amazonaws.${AWS::Region}.ssm
+      VpcId: !Ref VPC1
+      SubnetIds:
+        - !Ref VPC1EndpointsSubnet1
+        - !Ref VPC1EndpointsSubnet2
+      SecurityGroupIds:
+        - !Ref VPC1EndpointsSecurityGroup
+      VpcEndpointType: Interface
+      PrivateDnsEnabled: true
       Tags:
         - Key: Name
-          Value: VPC-2-Dual-Stack-Instance
+          Value: VPC1-SSM-Endpoint
 
-# ---------- IAM ROLES ----------
+  VPC1SSMMessagesEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      ServiceName: !Sub com.amazonaws.${AWS::Region}.ssmmessages
+      VpcId: !Ref VPC1
+      SubnetIds:
+        - !Ref VPC1EndpointsSubnet1
+        - !Ref VPC1EndpointsSubnet2
+      SecurityGroupIds:
+        - !Ref VPC1EndpointsSecurityGroup
+      VpcEndpointType: Interface
+      PrivateDnsEnabled: true
+      Tags:
+        - Key: Name
+          Value: VPC1-SSMMessages-Endpoint
+
+  VPC1EC2MessagesEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      ServiceName: !Sub com.amazonaws.${AWS::Region}.ec2messages
+      VpcId: !Ref VPC1
+      SubnetIds:
+        - !Ref VPC1EndpointsSubnet1
+        - !Ref VPC1EndpointsSubnet2
+      SecurityGroupIds:
+        - !Ref VPC1EndpointsSecurityGroup
+      VpcEndpointType: Interface
+      PrivateDnsEnabled: true
+      Tags:
+        - Key: Name
+          Value: VPC1-EC2Messages-Endpoint
+
+  VPC2SSMEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      ServiceName: !Sub com.amazonaws.${AWS::Region}.ssm
+      VpcId: !Ref VPC2
+      SubnetIds:
+        - !Ref VPC2EndpointsSubnet1
+        - !Ref VPC2EndpointsSubnet2
+      SecurityGroupIds:
+        - !Ref VPC2EndpointsSecurityGroup
+      VpcEndpointType: Interface
+      PrivateDnsEnabled: true
+      Tags:
+        - Key: Name
+          Value: VPC2-SSM-Endpoint
+
+  VPC2SSMMessagesEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      ServiceName: !Sub com.amazonaws.${AWS::Region}.ssmmessages
+      VpcId: !Ref VPC2
+      SubnetIds:
+        - !Ref VPC2EndpointsSubnet1
+        - !Ref VPC2EndpointsSubnet2
+      SecurityGroupIds:
+        - !Ref VPC2EndpointsSecurityGroup
+      VpcEndpointType: Interface
+      PrivateDnsEnabled: true
+      Tags:
+        - Key: Name
+          Value: VPC2-SSMMessages-Endpoint
+   
+  VPC2EC2MessagesEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      ServiceName: !Sub com.amazonaws.${AWS::Region}.ec2messages
+      VpcId: !Ref VPC2
+      SubnetIds:
+        - !Ref VPC2EndpointsSubnet1
+        - !Ref VPC2EndpointsSubnet2
+      SecurityGroupIds:
+        - !Ref VPC2EndpointsSecurityGroup
+      VpcEndpointType: Interface
+      PrivateDnsEnabled: true
+      Tags:
+        - Key: Name
+          Value: VPC2-EC2Messages-Endpoint
+
+  # ---------- IAM Roles ----------
   EC2SSMIAMRoleWorkloads:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
-              Service:
-                - ec2.amazonaws.com
-            Action:
-              - sts:AssumeRole
+              Service: ec2.amazonaws.com
+            Action: sts:AssumeRole
       ManagedPolicyArns:
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
       Path: /
+      Tags:
+        - Key: Name
+          Value: EC2-SSM-Role
 
   EC2SSMInstanceProfileWorkloads:
     Type: AWS::IAM::InstanceProfile
@@ -504,29 +895,254 @@ Resources:
       Roles:
         - !Ref EC2SSMIAMRoleWorkloads
 
-# ---------- Lattice SERVICE NETWORK (and Auth policy)
+  # ---------- EC2 Instances ----------
+  VPC1IPv4Instance:
+    Type: AWS::EC2::Instance
+    DependsOn: 
+      - VPC1SSMEndpoint
+      - VPC1SSMMessagesEndpoint
+      - VPC1EC2MessagesEndpoint
+    Properties:
+      InstanceType: t3.micro
+      IamInstanceProfile: !Ref EC2SSMInstanceProfileWorkloads
+      ImageId: !Ref LatestAmiId
+      SecurityGroupIds:
+        - !Ref VPC1InstanceSecurityGroup
+      SubnetId: !Ref VPC1IPv4OnlySubnet
+      UserData: 
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          yum update -y
+          yum install -y httpd
+          systemctl start httpd
+          systemctl enable httpd
+          echo "Hello from Application-1's version-1. This instance is deployed in an IPv4 only subnet." > /var/www/html/index.html
+      Tags:
+        - Key: Name
+          Value: VPC1-IPv4-Only-Instance
+
+  VPC1IPv6Instance:
+    Type: AWS::EC2::Instance
+    DependsOn: 
+      - VPC1SSMEndpoint
+      - VPC1SSMMessagesEndpoint
+      - VPC1EC2MessagesEndpoint
+    Properties:
+      InstanceType: t3.micro
+      IamInstanceProfile: !Ref EC2SSMInstanceProfileWorkloads
+      ImageId: !Ref LatestAmiId
+      SecurityGroupIds:
+        - !Ref VPC1InstanceSecurityGroup
+      SubnetId: !Ref VPC1IPv6OnlySubnet
+      UserData: 
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          yum update -y
+          yum install -y httpd
+          systemctl start httpd
+          systemctl enable httpd
+          echo "Hello from Application-1's version-2. This instance is deployed in an IPv6 only subnet." > /var/www/html/index.html
+      Tags:
+        - Key: Name
+          Value: VPC1-IPv6-Only-Instance
+
+  VPC2IPv4Instance:
+    Type: AWS::EC2::Instance
+    DependsOn: 
+      - VPC2SSMEndpoint
+      - VPC2SSMMessagesEndpoint
+      - VPC2EC2MessagesEndpoint
+    Properties:
+      InstanceType: t3.micro
+      IamInstanceProfile: !Ref EC2SSMInstanceProfileWorkloads
+      ImageId: !Ref LatestAmiId
+      SecurityGroupIds:
+        - !Ref VPC2InstanceSecurityGroup
+      SubnetId: !Ref VPC2IPv4OnlySubnet
+      UserData: 
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          yum update -y
+          yum install -y httpd
+          systemctl start httpd
+          systemctl enable httpd
+          echo "Hello from Application-2's version-1. This instance is deployed in an IPv4 only subnet." > /var/www/html/index.html
+      Tags:
+        - Key: Name
+          Value: VPC2-IPv4-Only-Instance
+
+  VPC2DualStackInstance:
+    Type: AWS::EC2::Instance
+    DependsOn: 
+      - VPC2SSMEndpoint
+      - VPC2SSMMessagesEndpoint
+      - VPC2EC2MessagesEndpoint
+    Properties:
+      InstanceType: t3.micro
+      IamInstanceProfile: !Ref EC2SSMInstanceProfileWorkloads
+      ImageId: !Ref LatestAmiId
+      SecurityGroupIds:
+        - !Ref VPC2InstanceSecurityGroup
+      SubnetId: !Ref VPC2DualStackSubnet
+      UserData: 
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          yum update -y
+          yum install -y httpd
+          systemctl start httpd
+          systemctl enable httpd
+          echo "Hello from Application-2's version-2. This instance is deployed in a dual stack subnet." > /var/www/html/index.html
+      Tags:
+        - Key: Name
+          Value: VPC2-Dual-Stack-Instance
+
+  # ---------- Lambda Resources ----------
+  LambdaBasicExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      Path: /
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: CustomLambdaEC2DescribePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ec2:DescribeNetworkInterfaces
+                Resource: '*'
+      Tags:
+        - Key: Name
+          Value: IPv6-Lambda-Role
+
+  CustomFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: index.lambda_handler
+      Description: "Retrieves IPv6 address of EC2 instance"
+      Timeout: 30
+      MemorySize: 128
+      Role: !GetAtt LambdaBasicExecutionRole.Arn
+      Runtime: python3.11
+      Code:
+        ZipFile: |
+          import json
+          import logging
+          import cfnresponse
+          import boto3
+          
+          logger = logging.getLogger()
+          logger.setLevel(logging.INFO)
+
+          def lambda_handler(event, context):
+              logger.info('Event: {}'.format(json.dumps(event)))
+              try:
+                  responseData = {}
+                  if event['RequestType'] == 'Delete':
+                      logger.info('Delete operation')
+                      cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
+                      return
+                  
+                  if event['RequestType'] in ["Create", "Update"]:
+                      ResourceRef = event['ResourceProperties']['ResourceRef']
+                      ec2 = boto3.client('ec2')
+                      response = ec2.describe_network_interfaces(
+                          Filters=[{'Name': 'attachment.instance-id', 'Values': [ResourceRef]}]
+                      )
+                      
+                      if response['NetworkInterfaces']:
+                          ipv6_addresses = response['NetworkInterfaces'][0].get('Ipv6Addresses', [])
+                          if ipv6_addresses:
+                              responseData['Ipv6Address'] = ipv6_addresses[0]['Ipv6Address']
+                              logger.info(f"Retrieved IPv6 address: {responseData['Ipv6Address']}")
+                              cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)
+                              return
+                      
+                      raise Exception("No IPv6 address found")
+                  
+                  logger.info('Unexpected RequestType!')
+                  cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)
+              
+              except Exception as err:
+                  logger.error(str(err))
+                  responseData = {"Error": str(err)}
+                  cfnresponse.send(event, context, cfnresponse.FAILED, responseData)
+
+  CustomIpv6Resource1:
+    Type: AWS::CloudFormation::CustomResource
+    Properties:
+      ServiceToken: !GetAtt CustomFunction.Arn
+      ResourceRef: !Ref VPC1IPv6Instance
+
+  CustomIpv6Resource2:
+    Type: AWS::CloudFormation::CustomResource
+    Properties:
+      ServiceToken: !GetAtt CustomFunction.Arn
+      ResourceRef: !Ref VPC2DualStackInstance
+
+  # ---------- VPC Lattice Resources ----------
   ServiceNetwork:
     Type: AWS::VpcLattice::ServiceNetwork
     Properties:
-      Name: lattice-service-network
+      Name: ipv6-day-service-network
       AuthType: AWS_IAM
-  
+      Tags:
+        - Key: Name
+          Value: ipv6-day-service-network
+
   ServiceNetworkAuthPolicy:
     Type: AWS::VpcLattice::AuthPolicy
     Properties:
       ResourceIdentifier: !Ref ServiceNetwork
       Policy:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal: '*'
             Action: '*'
             Resource: '*'
 
-# ---------- AMAZON VPC LATTICE Services related resources ----------
+  LatticeApp1SNAssociation:
+    Type: AWS::VpcLattice::ServiceNetworkVpcAssociation
+    Properties:
+      SecurityGroupIds:
+        - !Ref VPC1LatticeSecurityGroup
+      ServiceNetworkIdentifier: !Ref ServiceNetwork
+      VpcIdentifier: !Ref VPC1
+
+  LatticeApp2SNAssociation:
+    Type: AWS::VpcLattice::ServiceNetworkVpcAssociation
+    Properties:
+      SecurityGroupIds:
+        - !Ref VPC2LatticeSecurityGroup
+      ServiceNetworkIdentifier: !Ref ServiceNetwork
+      VpcIdentifier: !Ref VPC2
+
+  App1ServiceNetworkAssociation:
+    Type: AWS::VpcLattice::ServiceNetworkServiceAssociation
+    Properties:
+      ServiceNetworkIdentifier: !Ref ServiceNetwork
+      ServiceIdentifier: !Ref App1
+
+  App2ServiceNetworkAssociation:
+    Type: AWS::VpcLattice::ServiceNetworkServiceAssociation
+    Properties:
+      ServiceNetworkIdentifier: !Ref ServiceNetwork
+      ServiceIdentifier: !Ref App2
+
+
   App1IPv4TargetGroup:
     Type: AWS::VpcLattice::TargetGroup
+    DeletionPolicy: Delete
     Properties:
-      Name: app-1-ipv4-target-group
+      Name: app-1-ipv4-targets
       Type: INSTANCE
       Config:
         Protocol: HTTP
@@ -541,8 +1157,9 @@ Resources:
 
   App2IPv4TargetGroup:
     Type: AWS::VpcLattice::TargetGroup
+    DeletionPolicy: Delete
     Properties:
-      Name: app-2-ipv4-target-group
+      Name: app-2-ipv4-targets
       Type: INSTANCE
       Config:
         Protocol: HTTP
@@ -557,8 +1174,9 @@ Resources:
 
   App1IPv6TargetGroup:
     Type: AWS::VpcLattice::TargetGroup
+    DeletionPolicy: Delete
     Properties:
-      Name: app-1-ipv6-target-group
+      Name: app-1-ipv6-targets
       Type: IP
       Config:
         Protocol: HTTP
@@ -569,23 +1187,25 @@ Resources:
         HealthCheck:
           Enabled: false
       Targets:
-        - Id: !GetAtt CustomIpv6Resource.Ipv6Address
+        - Id: !GetAtt CustomIpv6Resource1.Ipv6Address
           Port: 80
 
   App2IPv6TargetGroup:
     Type: AWS::VpcLattice::TargetGroup
+    DeletionPolicy: Delete
     Properties:
-      Name: app-2-dual-stack-target-group
-      Type: INSTANCE
+      Name: app-2-dual-stack-target
+      Type: IP
       Config:
         Protocol: HTTP
         Port: 80
         ProtocolVersion: HTTP1
         VpcIdentifier: !Ref VPC2
+        IpAddressType: "IPV6"
         HealthCheck:
           Enabled: false
       Targets:
-        - Id: !Ref VPC2DualStackInstance
+        - Id: !GetAtt CustomIpv6Resource2.Ipv6Address
           Port: 80
 
   App1:
@@ -614,6 +1234,9 @@ Resources:
   
   App1Listener:
     Type: AWS::VpcLattice::Listener
+    DependsOn:
+      - App1IPv4TargetGroup
+      - App1IPv6TargetGroup
     Properties:
       ServiceIdentifier: !Ref App1
       Protocol: HTTP
@@ -626,6 +1249,9 @@ Resources:
 
   App2Listener:
     Type: AWS::VpcLattice::Listener
+    DependsOn:
+    - App2IPv4TargetGroup
+    - App2IPv6TargetGroup
     Properties:
       ServiceIdentifier: !Ref App2
       Protocol: HTTP
@@ -658,10 +1284,21 @@ Resources:
             Action: '*'
             Resource: '*'
 
-# ---------- LOG GROUP ----------
+  # ---------- Log Groups ----------
+  VPCFlowLogsGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: "/vpc/VPC-Flow-Logs"    # Added this line
+      RetentionInDays: 30
+      Tags:
+        - Key: Name
+          Value: VPC-Flow-Logs
+
   App1ServiceLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
+      LogGroupName: "/aws/vpc-lattice/lattice-app-1-lg"    # Added this line
+      RetentionInDays: 30
       Tags:
         - Key: Name
           Value: lattice-app-1-lg
@@ -669,113 +1306,130 @@ Resources:
   App2ServiceLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
+      LogGroupName: "/aws/vpc-lattice/lattice-app-2-lg"    # Added this line
+      RetentionInDays: 30
       Tags:
         - Key: Name
           Value: lattice-app-2-lg
 
-# Lattice Service Associations with Service Network
-
-  LatticeApp1SNAssociation:
-    Type: AWS::VpcLattice::ServiceNetworkServiceAssociation
+  LatticeServiceLogsGroup:
+    Type: AWS::Logs::LogGroup
     Properties:
-      ServiceIdentifier: !Ref App1
-      ServiceNetworkIdentifier: !Ref ServiceNetwork
-
-  LatticeApp2SNAssociation:
-    Type: AWS::VpcLattice::ServiceNetworkServiceAssociation
-    Properties:
-      ServiceIdentifier: !Ref App2
-      ServiceNetworkIdentifier: !Ref ServiceNetwork
-
-# CustomResource for fetching IPv6 address
-  LambdaBasicExecutionRole:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-        - Effect: Allow
-          Principal:
-            Service: lambda.amazonaws.com
-          Action: sts:AssumeRole
-      Path: /
-      Policies:
-        - PolicyName: CustomLambdaEC2DescribePolicy
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: Allow
-                Action:
-                  - logs:CreateLogGroup
-                  - logs:CreateLogStream
-                  - logs:PutLogEvents
-                Resource: arn:aws:logs:*:*:*
-              - Effect: Allow
-                Action:
-                  - ec2:DescribeNetworkInterfaces
-                Resource: '*'
-
-  CustomIpv6Resource:
-    Type: AWS::CloudFormation::CustomResource
-    Properties:
-      ServiceToken: !GetAtt 'CustomFunction.Arn'
-      ResourceRef: !Ref VPC1IPv6Instance
-
-  CustomFunction:
-    Type: AWS::Lambda::Function
-    Properties:
-      Handler: index.lambda_handler
-      Description: "Retrieves IPv6 address of EC2 instance"
-      Timeout: 30
-      Role: !GetAtt 'LambdaBasicExecutionRole.Arn'
-      Runtime: python3.7
-      Code:
-        ZipFile: |
-          import json
-          import logging
-          import cfnresponse
-          import boto3
-          
-          logger = logging.getLogger()
-          logger.setLevel(logging.INFO)
-
-          def lambda_handler(event, context):
-            logger.info('got event {}'.format(event))
-            try:
-              responseData = {}
-              if event['RequestType'] == 'Delete':
-                logger.info('Incoming RequestType: Delete operation')
-                cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
-              if event['RequestType'] in ["Create", "Update"]:
-                # 1. retrieve resource reference ID or Name
-                ResourceRef=event['ResourceProperties']['ResourceRef']
-                # 2. retrieve boto3 client
-                client = boto3.client('ec2')
-                # 3. Invoke describe/retrieve function using ResourceRef
-                response = response=client.describe_network_interfaces(Filters=[{'Name':'attachment.instance-id', 'Values':[ResourceRef] }])
-                # 4. Parse and return required attributes
-                responseData = {}
-                responseData['Ipv6Address'] = response.get('NetworkInterfaces')[0]['Ipv6Addresses'][0]['Ipv6Address']
-                logger.info('Retrieved IPv6 address!')
-                cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)
-              else:
-                logger.info('Unexpected RequestType!')
-                cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)
-            except Exception as err:
-              logger.error(err)
-              responseData = {"Data": str(err)}
-              cfnresponse.send(event,context,cfnresponse.FAILED,responseData)
+      LogGroupName: "/aws/vpc-lattice/VPC-Lattice-Service-Logs"    # Added this line
+      RetentionInDays: 30
+      Tags:
+        - Key: Name
+          Value: VPC-Lattice-Service-Logs
 
 
 Outputs:
-  Vpc1Id:
-    Description: Amazon VPC ID
-    Value: !Ref VPC1
-  Vpc2Id:
-    Description: Amazon VPC ID
-    Value: !Ref VPC2
-  VPC1LatticeSecurityGroup:
-    Description: Security Group (Lattice VPC association) ID
-    Value: !Ref VPC1LatticeSecurityGroup
-  VPC2LatticeSecurityGroup:
-    Description: Security Group (Lattice VPC association) ID
-    Value: !Ref VPC2LatticeSecurityGroup
+  VPCInformation:
+    Description: VPC Information
+    Value: !Sub |
+      VPC1:
+        ID: ${VPC1}
+        CIDR: 10.1.0.0/16
+        IPv6: ${VPC1IPv6CIDR}
+      VPC2:
+        ID: ${VPC2}
+        CIDR: 10.2.0.0/16
+        IPv6: ${VPC2IPv6CIDR}
+
+  SubnetInformation:
+    Description: Subnet Information
+    Value: !Sub |
+      VPC1 Subnets:
+        Public AZ1: ${VPC1PublicSubnet1}
+        Public AZ2: ${VPC1PublicSubnet2}
+        Private AZ1: ${VPC1IPv4OnlySubnet}
+        Private AZ2: ${VPC1IPv6OnlySubnet}
+      VPC2 Subnets:
+        Public AZ1: ${VPC2PublicSubnet1}
+        Public AZ2: ${VPC2PublicSubnet2}
+        Private AZ1: ${VPC2IPv4OnlySubnet}
+        Private AZ2: ${VPC2DualStackSubnet}
+
+  NetworkingResources:
+    Description: Networking Resources
+    Value: !Sub |
+      NAT Gateways:
+        VPC1 AZ1: ${VPC1NATGW1}
+        VPC1 AZ2: ${VPC1NATGW2}
+        VPC2 AZ1: ${VPC2NATGW1}
+        VPC2 AZ2: ${VPC2NATGW2}
+      Route Tables:
+        VPC1 Public: ${VPC1PublicRouteTable}
+        VPC1 Private AZ1: ${VPC1IPv4OnlySubnetRouteTable1}
+        VPC1 Private AZ2: ${VPC1IPv6OnlySubnetRouteTable2}
+        VPC2 Public: ${VPC2PublicRouteTable}
+        VPC2 Private AZ1: ${VPC2IPv4OnlySubnetRouteTable1}
+        VPC2 Private AZ2: ${VPC2DualStackSubnetRouteTable2}
+
+  SecurityGroups:
+    Description: Security Group Information
+    Value: !Sub |
+      VPC1:
+        Instance SG: ${VPC1InstanceSecurityGroup}
+        Endpoints SG: ${VPC1EndpointsSecurityGroup}
+        Lattice SG: ${VPC1LatticeSecurityGroup}
+      VPC2:
+        Instance SG: ${VPC2InstanceSecurityGroup}
+        Endpoints SG: ${VPC2EndpointsSecurityGroup}
+        Lattice SG: ${VPC2LatticeSecurityGroup}
+
+  EC2Instances:
+    Description: EC2 Instance Information
+    Value: !Sub |
+      VPC1:
+        IPv4 Instance:
+          ID: ${VPC1IPv4Instance}
+          Private IP: ${VPC1IPv4Instance.PrivateIp}
+        IPv6 Instance:
+          ID: ${VPC1IPv6Instance}
+          IPv6: ${CustomIpv6Resource1.Ipv6Address}
+      VPC2:
+        IPv4 Instance:
+          ID: ${VPC2IPv4Instance}
+          Private IP: ${VPC2IPv4Instance.PrivateIp}
+        Dual Stack Instance:
+          ID: ${VPC2DualStackInstance}
+          IPv6: ${CustomIpv6Resource2.Ipv6Address}
+
+  VPCEndpoints:
+    Description: VPC Endpoint Information
+    Value: !Sub |
+      VPC1:
+        SSM: ${VPC1SSMEndpoint}
+        SSMMessages: ${VPC1SSMMessagesEndpoint}
+        EC2Messages: ${VPC1EC2MessagesEndpoint}
+      VPC2:
+        SSM: ${VPC2SSMEndpoint}
+        SSMMessages: ${VPC2SSMMessagesEndpoint}
+        EC2Messages: ${VPC2EC2MessagesEndpoint}
+
+  LatticeResources:
+    Description: VPC Lattice Resource Information
+    Value: !Sub |
+      Service Network: ${ServiceNetwork}
+      Services:
+        Service 1: ${App1}
+        Service 2: ${App2}
+      VPC Associations:
+        VPC1: ${LatticeApp1SNAssociation}
+        VPC2: ${LatticeApp2SNAssociation}
+
+  SSMConnectCommands:
+    Description: SSM Session Manager Connection Commands
+    Value: !Sub |
+      VPC1:
+        IPv4 Instance: aws ssm start-session --target ${VPC1IPv4Instance}
+        IPv6 Instance: aws ssm start-session --target ${VPC1IPv6Instance}
+      VPC2:
+        IPv4 Instance: aws ssm start-session --target ${VPC2IPv4Instance}
+        Dual Stack Instance: aws ssm start-session --target ${VPC2DualStackInstance}
+
+  LogGroups:
+    Description: CloudWatch Log Group Information
+    Value: !Sub |
+      VPC Flow Logs: ${VPCFlowLogsGroup}
+      Lattice Service Logs: ${LatticeServiceLogsGroup}


### PR DESCRIPTION
CloudFormation Configuration Changes:

* User data missing from original file: Added EC2 User Data Configuration to install httpd and index.html file with text describing App#, Version and type of subnet (IPv4/6/dual-stack)
  * Output matches screenshots from blog post

* Remove Parameters “SSHClientIP” and “SSHClientIPv6” and associated security group rules
  * SSH will be supported by Session Manage via AWS Console
* Fixed issue where IGW wasn't attaching to VPC1. Added VPCGatewayAttachment for VPC1 IGW
* Updated Lambda “CustomerFucntion” to user Python 3.11
* Added VPC2 IGW with VPCGatewayAttachment
* Created EIGW's for VPC1 and VPC2 allowing IPv6 only subnet to install httpd.
* Corrected multiple resource names to match blog post screenshots
* Created Variables for VPCLatticeIPv4PrefixList and VPCLatticeIPv6PrefixList for VPC Lattice managed prefix list
* Referenced variable for VPC Lattice Managed Prefix List (IPv4/IPv6) to Instance Security Group rules allowing 169.254.171.0/24 and Fd00::/10 (Link-local addresses used by VPC Lattice Service)
* Modified Security Group Rule descriptions to align with rule function
* Created Private Route Tables:
VPC1IPv4SubnetRouteTable1 - IPv4 Only Subnet in VPC1 AZ-A with Route to VPC1NATGW1 and EIGW VPC1IPv6SubnetRouteTable2 - IPv6 Only Subnet in VPC1 AZ-B with Route to VPC1NATGW2 and EIGW VPC2IPv4SubnetRouteTable1 - IPv4 Only Subnet in VPC2 AZ-A with Route to VPC2NATGW1 and EIGW VPC2DualStackSubnetRouteTable2 - for Dual-Stack Subnet in VPC2 AZ-B with Route to VPC2NATGW2 and EIGW

- Created Private Subnets:
VPC1IPv4Subnet - IPv4 Only Subnet AZ-A
VPC1IPv6Subnet - IPv6 Only Subnet AZ-B
VPC1EndpointsSubnet1 - Dual-Stack for VPC1 Endpoints in AZ-A
VPC1EndpointsSubnet2 - Dual-Stack for VPC1 Endpoints in AZ-B
VPC2IPv4Subnet - IPv4 Only Subnet AZ-A
VPC2DualStackSubnet - Dual-Stack Subnet AZ-B
VPC2EndpointsSubnet1 - Dual-Stack for VPC2 Endpoints in AZ-A
VPC2EndpointsSubnet2 - Dual-Stack for VPC2 Endpoints in AZ-B
* Added all relevant Subnet to Route Table Associations
* Created Public Route Table for Public Subnets in VPC1 and VPC2
* Created two Dual-Stack Public Subnets per VPC (AZ-A and AZ-B) for NATGW’s with Routes to IGW
* Created/Requested 4 EIP's, 2 Per VPC for NATGW's (AZ-A and AZ-B)
* Created two NATGW's per VPC (AZ-A and AZ-B)
* Configured NATGW's to be deployed in two different Public AZ's per VPC (A/B)
* Created Public/Private routes for IPv4/6 Default Routes to IGW(Public RT’s)/NATGW(Private RT’s)
* Create route in IPv6 Only subnet route table for 64:ff9b::/96 in support of DNS64 to ensure IPV6 only instance can download linux packages from the internet
* Routes to NATGW are mapped correctly based on AZ
* Endpoints created in Endpoint Subnets (Private) containing only Local and VPC Lattice Routes
* Added two rules to each Endpoint Security Group that adds both Public Subnet Private CIDR's to allow NATGW's traffic into endpoint (supporting SSM/EC2Messages/SSMMessages Endpoints). Allowing IPv6 only instances to reach private Endpoints when NAT64'd via NATGW
* Modified name of CloudFormation custom resource “CustomIpv6Resource“ to ”CustomIpv6Resource1“ for VPC1IPv6Instance and created an additional CloudFormation custom resource named ”CustomIpv6Resource2“ for VPC2DualStackInstance
* Lambda Function will obtain the IPv6 address for the two IPv6 Instances (IPv6-Only and Dual-Stack) and saved as these resources.
* This is later referenced to input the IPv6 address into the Target Groups: (!GetAtt CustomIpv6Resource1.Ipv6Address)
* app-1-ipv6-targets
* app-2-dual-stack-targets
* Fixed issue where Stack Failed to delete when Target Groups were added manually and not by CloudFormation.